### PR TITLE
quickstart: improve the description about project structure

### DIFF
--- a/docs/manual-zh/quick-start/create-project.mdx
+++ b/docs/manual-zh/quick-start/create-project.mdx
@@ -71,7 +71,51 @@ $ npm install
 
 > 如果通过 GitHub 项目创建的 JSAR 空间小程序，推荐为你的项目添加 "jsar-widget" 的主题（Topic），这样可以方便 JSAR 开发团队以及社区在 [GitHub #jsar-widget](https://github.com/topics/jsar-widget) 上发现你的项目。
 
-## package.json 字段说明
+## 项目结构
+
+无论通过 npm 还是 GitHub Template 创建的项目，项目结构都是一致的。
+
+```
+.
+├── lib
+│   └── index.ts
+├── model
+│   └── foobar.glb
+├── icon.png
+├── main.xsml
+├── tsconfig.json
+└── package.json
+```
+
+其中:
+
+- `lib` 目录一般是用来存放脚本文件，比如 `TypeScript`、`JavaScript` 等
+- `model` 目录一般是用来存放模型文件，比如 `glTF`、`glb` 等
+- `icon.png` 是小程序的图标文件，YodaOS Master 系统中的商店和小程序列表中会展示该图标
+- `main.xsml` 是小程序的入口文件，它是一个 XSML 文件，用于描述小程序的界面和交互逻辑
+
+以上的文件和目录都是推荐命名和位置，但不是强制的，开发者可以根据自己的喜好进行调整，比如可以将 `lib` 目录改为 `src`，`model` 目录改为 `assets` 等。
+
+[`tsconfig.json`](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) 是 TypeScript 配置文件，用于配置 TypeScript 编译器的行为以及 VSCode 的智能提示。
+
+```json
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "types": [
+      "@yodaos-jsar/types"
+    ]
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}
+```
+
+> 通过模版创建的项目，已经包含了 `tsconfig.json` 文件，开发者也可以按照自己的需求修改其中的配置，但一般不推荐开发者修改。
+
+[`package.json`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) 是每一个 npm 项目的标准配置文件，JSAR 基于 npm 的 package.json 规范进行了一些拓展，以下是在 JSAR 中完整 package.json 说明：
 
 | 字段 | 类型 | 必填 | 说明 |
 | --- | --- | --- | --- |
@@ -92,22 +136,3 @@ $ npm install
 2. `main` 字段必须是 xsml 文件，不支持 JavaScript 文件。
 3. `files` 字段必须包含 xsml 文件和`icon.png`，后者用于展示在商店及小程序列表。
 4. 请务必添加 `@yodaos-jsar/types` 这个依赖，它包含了空间小程序的类型定义文件，这样可以在开发过程中获得类型检查和自动补全的功能。
-
-## 使用 TypeScript 智能提示
-
-为了使用 JSAR 的 TypeScript 智能提示，除了安装 `@yodaos-jsar/types` 之外，还需要在项目根目录下创建 `tsconfig.json` 文件，内容如下：
-
-```json
-{
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
-    "types": [
-      "@yodaos-jsar/types"
-    ]
-  },
-  "exclude": [
-    "node_modules"
-  ]
-}
-```

--- a/docs/manual/quick-start/create-project.mdx
+++ b/docs/manual/quick-start/create-project.mdx
@@ -71,7 +71,51 @@ As shown in the image above, fill in the required information to create a new Gi
 
 > For JSAR space widget projects created through GitHub, we recommend adding the "jsar-widget" topic to your project. This will make it easier for the JSAR development team and the community to discover your project on [GitHub #jsar-widget](https://github.com/topics/jsar-widget).
 
-## Explanation of package.json Fields
+## Project Structure
+
+Whether created through npm or GitHub Template, the project structure remains consistent.
+
+```
+.
+├── lib
+│   └── index.ts
+├── model
+│   └── foobar.glb
+├── icon.png
+├── main.xsml
+├── tsconfig.json
+└── package.json
+```
+
+Where:
+
+- The `lib` directory is generally used to store script files, such as `TypeScript`, `JavaScript`, etc.
+- The `model` directory is generally used to store model files, such as `glTF`, `glb`, etc.
+- `icon.png` is the icon file for the mini-program. The YodaOS Master system in the store and the mini-program list will display this icon.
+- `main.xsml` is the entry file for the mini-program. It is an XSML file used to describe the interface and interactive logic of the mini-program.
+
+The above files and directories are recommended names and locations, but not mandatory. Developers can adjust them according to their preferences, such as changing the `lib` directory to `src`, the `model` directory to `assets`, etc.
+
+The [`tsconfig.json`](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html) is the TypeScript configuration file, used to configure the behavior of the TypeScript compiler and VSCode's intelligent suggestions.
+
+```json
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es6",
+    "types": [
+      "@yodaos-jsar/types"
+    ]
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}
+```
+
+> Projects created from the template already include the `tsconfig.json` file. Developers can modify the configuration according to their needs, but it is generally not recommended.
+
+The [`package.json`](https://docs.npmjs.com/cli/v10/configuring-npm/package-json) is the standard configuration file for every npm project. JSAR extends the npm package.json specification, and here is a complete explanation within JSAR:
 
 | Field | Type | Required | Description |
 | --- | --- | --- | --- |
@@ -92,22 +136,3 @@ Important notes:
 2. The `main` field must point to an xsml file and does not support JavaScript files.
 3. The `files` field must include xsml files and `icon.png`, which is used for display in the store and the list of mini-programs.
 4. Be sure to add the `@yodaos-jsar/types` dependency. It contains type definition files for space mini-programs, enabling type checking and autocompletion during development.
-
-## Enable TypeScript IntelliSense
-
-To enable TypeScript IntelliSense for JSAR, you need to create a `tsconfig.json` file in the project's root directory with the following content:
-
-```json
-{
-  "compilerOptions": {
-    "module": "commonjs",
-    "target": "es6",
-    "types": [
-      "@yodaos-jsar/types"
-    ]
-  },
-  "exclude": [
-    "node_modules"
-  ]
-}
-```

--- a/pages/manual/[ver]/[...id].tsx
+++ b/pages/manual/[ver]/[...id].tsx
@@ -130,11 +130,13 @@ function createCustomMdxComponents(router: NextRouter): MDXComponents {
             language={lang}
             theme={github}
             text={code.replace(/\n$/, '')}
-            showLineNumbers={true}
+            showLineNumbers
             codeContainerStyle={{
               padding: '0.5rem',
-              fontSize: '1.15em',
-              width: '100%',
+              fontSize: '1em',
+              fontFamily: 'monospace',
+              minWidth: 'calc(100% - 1rem)',
+              overflowX: 'auto',
             }}
           />
         </Typography.Paragraph>
@@ -162,6 +164,7 @@ function createCustomMdxComponents(router: NextRouter): MDXComponents {
               overflow: auto;
             }
             tr {
+              word-break: auto-phrase;
               background-color: var(--color-canvas-default);
               border-top: 1px solid var(--color-border-muted);
             }


### PR DESCRIPTION
Thanks for @yypikachu's feedback will be addressed by adding a new section in the "Creating a Project" chapter, titled "Project Structure." This section includes the previous explanations of the `package.json` fields and adds explanations for `tsconfig.json` and other files. Additionally, this PR resolves a markdown rendering format issue.

感谢 @yypikachu 反馈的问题，这里将在“创建项目”章节中，添加一个新的部分：项目结构，它包含了之前的 package.json 字段说明，以及添加了 tsconfig.json 和其他文件的说明，另外这个 PR 也修复了一个 markdown 渲染的格式问题。
